### PR TITLE
Optimized function WriteBit in OneWire

### DIFF
--- a/src/support_one_wire.cpp
+++ b/src/support_one_wire.cpp
@@ -177,24 +177,14 @@ void OneWire::write_bit(uint8_t v)
 {
 	IO_REG_TYPE mask=bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
-
-	if (v & 1) {
-		noInterrupts();
-		DIRECT_WRITE_LOW(reg, mask);
-		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(10);
-		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
-		interrupts();
-		delayMicroseconds(55);
-	} else {
-		noInterrupts();
-		DIRECT_WRITE_LOW(reg, mask);
-		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(65);
-		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
-		interrupts();
-		delayMicroseconds(5);
-	}
+	
+	noInterrupts();
+	DIRECT_WRITE_LOW(reg, mask);
+	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+	delayMicroseconds(v & 1 ? 10 : 65);
+	DIRECT_WRITE_HIGH(reg, mask);	// drive output high
+	interrupts();
+	delayMicroseconds(v & 1 ? 55 : 5);
 }
 
 //


### PR DESCRIPTION
Optimized function in OneWire class called WriteBit to use comparators instead of if statements to get rid of repetitive code
